### PR TITLE
Create Bidi Level struct type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unicode-bidi"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["The Servo Project Developers"]
 license = "MIT / Apache-2.0"
 description = "Implementation of the Unicode Bidirectional Algorithm"

--- a/src/char_data/mod.rs
+++ b/src/char_data/mod.rs
@@ -9,8 +9,7 @@
 
 //! Accessor for `Bidi_Class` property from Unicode Character Database (UCD)
 
-// TODO: Make private after dropping deprecated call
-pub mod tables;
+mod tables;
 
 pub use self::tables::{BidiClass, UNICODE_VERSION};
 
@@ -46,7 +45,7 @@ fn bsearch_range_value_table(c: char, r: &'static [(char, char, BidiClass)]) -> 
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
 
     #[test]

--- a/src/format_chars.rs
+++ b/src/format_chars.rs
@@ -1,0 +1,42 @@
+// Copyright 2014 The html5ever Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Directional Formatting Characters
+//!
+//! http://www.unicode.org/reports/tr9/#Directional_Formatting_Characters
+
+// == Implicit ==
+/// ARABIC LETTER MARK
+pub const ALM: char = '\u{061C}';
+/// LEFT-TO-RIGHT MARK
+pub const LRM: char = '\u{200E}';
+/// RIGHT-TO-LEFT MARK
+pub const RLM: char = '\u{200F}';
+
+// == Explicit Isolates ==
+/// LEFT‑TO‑RIGHT ISOLATE
+pub const LRI: char = '\u{2066}';
+/// RIGHT‑TO‑LEFT ISOLATE
+pub const RLI: char = '\u{2067}';
+/// FIRST STRONG ISOLATE
+pub const FSI: char = '\u{2068}';
+/// POP DIRECTIONAL ISOLATE
+pub const PDI: char = '\u{2069}';
+
+// == Explicit Embeddings and Overrides ==
+/// LEFT-TO-RIGHT EMBEDDING
+pub const LRE: char = '\u{202A}';
+/// RIGHT-TO-LEFT EMBEDDING
+pub const RLE: char = '\u{202B}';
+/// LEFT-TO-RIGHT OVERRIDE
+pub const LRO: char = '\u{202D}';
+/// RIGHT-TO-LEFT OVERRIDE
+pub const RLO: char = '\u{202E}';
+/// POP DIRECTIONAL FORMATTING
+pub const PDF: char = '\u{202C}';

--- a/src/level.rs
+++ b/src/level.rs
@@ -1,0 +1,322 @@
+// Copyright 2017 The Servo Project Developers. See the
+// COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Bidi Embedding Level
+//!
+//! http://www.unicode.org/reports/tr9/#BD2
+
+use std::convert::{From, Into};
+
+use super::char_data::BidiClass;
+
+/// Embedding Level
+///
+/// Embedding Levels are numbers between 0 and 125 (inclusive), where even values denote a
+/// left-to-right (LTR) direction and odd values a right-to-left (RTL) direction.
+///
+/// This struct maintains a *valid* status for level numbers, meaning that creating a new level, or
+/// mutating an existing level, with the value smaller than `0` (before conversion to `u8`) or
+/// larger than 125 results in an `Error`.
+///
+/// http://www.unicode.org/reports/tr9/#BD2
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct Level(u8);
+
+pub const LTR_LEVEL: Level = Level(0);
+pub const RTL_LEVEL: Level = Level(1);
+
+const MAX_DEPTH: u8 = 125;
+/// During explicit level resolution, embedding level can go as high as `max_depth`.
+pub const MAX_EXPLICIT_DEPTH: u8 = MAX_DEPTH;
+/// During implicit level resolution, embedding level can go as high as `max_depth + 1`.
+pub const MAX_IMPLICIT_DEPTH: u8 = MAX_DEPTH + 1;
+
+/// Errors that can occur on Level creation or mutation
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    /// Out-of-range (invalid) embedding level number.
+    OutOfRangeNumber,
+}
+
+impl Level {
+    /// New LTR level with smallest number value (0).
+    #[inline]
+    pub fn ltr() -> Level {
+        LTR_LEVEL
+    }
+
+    /// New RTL level with smallest number value (1).
+    #[inline]
+    pub fn rtl() -> Level {
+        RTL_LEVEL
+    }
+
+    /// Maximum depth of the directional status stack during implicit resolutions.
+    pub fn max_implicit_depth() -> u8 {
+        MAX_IMPLICIT_DEPTH
+    }
+
+    /// Maximum depth of the directional status stack during explicit resolutions.
+    pub fn max_explicit_depth() -> u8 {
+        MAX_EXPLICIT_DEPTH
+    }
+
+    // == Inquiries ==
+
+    /// Create new level, fail if number is larger than `max_depth + 1`.
+    #[inline]
+    pub fn new(number: u8) -> Result<Level, Error> {
+        if number <= MAX_IMPLICIT_DEPTH {
+            Ok(Level(number))
+        } else {
+            Err(Error::OutOfRangeNumber)
+        }
+    }
+
+    /// Create new level, fail if number is larger than `max_depth`.
+    #[inline]
+    pub fn new_explicit(number: u8) -> Result<Level, Error> {
+        if number <= MAX_EXPLICIT_DEPTH {
+            Ok(Level(number))
+        } else {
+            Err(Error::OutOfRangeNumber)
+        }
+    }
+
+    // == Inquiries ==
+
+    /// The level number.
+    #[inline]
+    pub fn number(&self) -> u8 {
+        self.0
+    }
+
+    /// If this level is left-to-right.
+    #[inline]
+    pub fn is_ltr(&self) -> bool {
+        self.0 % 2 == 0
+    }
+
+    /// If this level is right-to-left.
+    #[inline]
+    pub fn is_rtl(&self) -> bool {
+        self.0 % 2 == 1
+    }
+
+    // == Mutators ==
+
+    /// Raise level by `amount`, fail if number is larger than `max_depth + 1`.
+    #[inline]
+    pub fn raise(&mut self, amount: u8) -> Result<(), Error> {
+        match self.0.checked_add(amount) {
+            Some(number) => {
+                if number <= MAX_IMPLICIT_DEPTH {
+                    self.0 = number;
+                    Ok(())
+                } else {
+                    Err(Error::OutOfRangeNumber)
+                }
+            }
+            None => Err(Error::OutOfRangeNumber),
+        }
+    }
+
+    /// Raise level by `amount`, fail if number is larger than `max_depth`.
+    #[inline]
+    pub fn raise_explicit(&mut self, amount: u8) -> Result<(), Error> {
+        match self.0.checked_add(amount) {
+            Some(number) => {
+                if number <= MAX_EXPLICIT_DEPTH {
+                    self.0 = number;
+                    Ok(())
+                } else {
+                    Err(Error::OutOfRangeNumber)
+                }
+            }
+            None => Err(Error::OutOfRangeNumber),
+        }
+    }
+
+    /// Lower level by `amount`, fail if number goes below zero.
+    #[inline]
+    pub fn lower(&mut self, amount: u8) -> Result<(), Error> {
+        match self.0.checked_sub(amount) {
+            Some(number) => {
+                self.0 = number;
+                Ok(())
+            }
+            None => Err(Error::OutOfRangeNumber),
+        }
+    }
+
+    // == Helpers ==
+
+    /// The next LTR (even) level greater than this.
+    #[inline]
+    pub fn new_explicit_next_ltr(&self) -> Result<Level, Error> {
+        Level::new_explicit(self.0 + 2 & !1)
+    }
+
+    /// The next RTL (odd) level greater than this.
+    #[inline]
+    pub fn new_explicit_next_rtl(&self) -> Result<Level, Error> {
+        Level::new_explicit((self.0 + 1) | 1)
+    }
+
+    /// The lowest RTL (odd) level greater than or equal to this.
+    #[inline]
+    pub fn new_lowest_ge_rtl(&self) -> Result<Level, Error> {
+        Level::new(self.0 | 1)
+    }
+
+    /// Generate a character type based on a level (as specified in steps X10 and N2).
+    #[inline]
+    pub fn bidi_class(&self) -> BidiClass {
+        if self.is_rtl() {
+            BidiClass::R
+        } else {
+            BidiClass::L
+        }
+    }
+
+    pub fn vec(v: &[u8]) -> Vec<Level> {
+        v.iter().map(|&x| x.into()).collect()
+    }
+}
+
+impl Into<u8> for Level {
+    /// Convert to the level number
+    #[inline]
+    fn into(self) -> u8 {
+        self.number()
+    }
+}
+
+impl From<u8> for Level {
+    /// Create level by number
+    #[inline]
+    fn from(number: u8) -> Level {
+        Level::new(number).expect("Level number error")
+    }
+}
+
+/// Used for matching levels in conformance tests
+impl<'a> PartialEq<&'a str> for Level {
+    #[inline]
+    fn eq(&self, s: &&'a str) -> bool {
+        if *s == "x" {
+            true
+        } else {
+            *s == self.0.to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        assert_eq!(Level::new(0), Ok(Level(0)));
+        assert_eq!(Level::new(1), Ok(Level(1)));
+        assert_eq!(Level::new(10), Ok(Level(10)));
+        assert_eq!(Level::new(125), Ok(Level(125)));
+        assert_eq!(Level::new(126), Ok(Level(126)));
+        assert_eq!(Level::new(127), Err(Error::OutOfRangeNumber));
+        assert_eq!(Level::new(255), Err(Error::OutOfRangeNumber));
+    }
+
+    #[test]
+    fn test_new_explicit() {
+        assert_eq!(Level::new_explicit(0), Ok(Level(0)));
+        assert_eq!(Level::new_explicit(1), Ok(Level(1)));
+        assert_eq!(Level::new_explicit(10), Ok(Level(10)));
+        assert_eq!(Level::new_explicit(125), Ok(Level(125)));
+        assert_eq!(Level::new_explicit(126), Err(Error::OutOfRangeNumber));
+        assert_eq!(Level::new_explicit(255), Err(Error::OutOfRangeNumber));
+    }
+
+    #[test]
+    fn test_is_ltr() {
+        assert_eq!(Level(0).is_ltr(), true);
+        assert_eq!(Level(1).is_ltr(), false);
+        assert_eq!(Level(10).is_ltr(), true);
+        assert_eq!(Level(11).is_ltr(), false);
+        assert_eq!(Level(124).is_ltr(), true);
+        assert_eq!(Level(125).is_ltr(), false);
+    }
+
+    #[test]
+    fn test_is_rtl() {
+        assert_eq!(Level(0).is_rtl(), false);
+        assert_eq!(Level(1).is_rtl(), true);
+        assert_eq!(Level(10).is_rtl(), false);
+        assert_eq!(Level(11).is_rtl(), true);
+        assert_eq!(Level(124).is_rtl(), false);
+        assert_eq!(Level(125).is_rtl(), true);
+    }
+
+    #[test]
+    fn test_raise() {
+        let mut level = Level::ltr();
+        assert_eq!(level.number(), 0);
+        assert!(level.raise(100).is_ok());
+        assert_eq!(level.number(), 100);
+        assert!(level.raise(26).is_ok());
+        assert_eq!(level.number(), 126);
+        assert!(level.raise(1).is_err()); // invalid!
+        assert!(level.raise(250).is_err()); // overflow!
+        assert_eq!(level.number(), 126);
+    }
+
+    #[test]
+    fn test_raise_explicit() {
+        let mut level = Level::ltr();
+        assert_eq!(level.number(), 0);
+        assert!(level.raise_explicit(100).is_ok());
+        assert_eq!(level.number(), 100);
+        assert!(level.raise_explicit(25).is_ok());
+        assert_eq!(level.number(), 125);
+        assert!(level.raise_explicit(1).is_err()); // invalid!
+        assert!(level.raise_explicit(250).is_err()); // overflow!
+        assert_eq!(level.number(), 125);
+    }
+
+    #[test]
+    fn test_lower() {
+        let mut level = Level::rtl();
+        assert_eq!(level.number(), 1);
+        assert!(level.lower(1).is_ok());
+        assert_eq!(level.number(), 0);
+        assert!(level.lower(1).is_err()); // underflow!
+        assert!(level.lower(250).is_err()); // underflow!
+        assert_eq!(level.number(), 0);
+    }
+
+    #[test]
+    fn test_into() {
+        let level = Level::rtl();
+        assert_eq!(1u8, level.into());
+    }
+
+    #[test]
+    fn test_vec() {
+        assert_eq!(
+            Level::vec(&[0, 1, 125]),
+            vec![Level(0), Level(1), Level(125)]
+        );
+    }
+
+    #[test]
+    fn test_string_eq() {
+        assert_eq!(Level::vec(&[0, 1, 4, 125]), vec!["0", "1", "x", "125"]);
+        assert_ne!(Level::vec(&[0, 1, 4, 125]), vec!["0", "1", "5", "125"]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,8 @@
 //! // This paragraph has embedding level 1 because its first strong character is RTL.
 //! assert_eq!(info.paragraphs.len(), 1);
 //! let paragraph_info = &info.paragraphs[0];
-//! assert_eq!(paragraph_info.level, 1);
+//! assert_eq!(paragraph_info.level.number(), 1);
+//! assert_eq!(paragraph_info.level.is_rtl(), true);
 //!
 //! // Re-ordering is done after wrapping each paragraph into a sequence of
 //! // lines. For this example, I'll just use a single line that spans the
@@ -55,21 +56,25 @@
 #[macro_use]
 extern crate matches;
 
+pub mod format_chars;
+pub mod level;
+
 mod char_data;
 mod explicit;
-mod prepare;
 mod implicit;
+mod prepare;
 
 pub use char_data::{BidiClass, bidi_class, UNICODE_VERSION};
-use BidiClass::*;
-
-#[deprecated(since="0.2.6", note="please use `char_data` module instead")]
-pub use char_data::tables;
+pub use level::Level;
+pub use prepare::LevelRun;
 
 use std::borrow::Cow;
 use std::cmp::{max, min};
 use std::iter::repeat;
 use std::ops::Range;
+
+use BidiClass::*;
+use format_chars as chars;
 
 /// Output of `process_text`
 ///
@@ -81,13 +86,31 @@ pub struct BidiInfo {
     pub classes: Vec<BidiClass>,
 
     /// The directional embedding level of each byte in the text.
-    pub levels: Vec<u8>,
+    pub levels: Vec<Level>,
 
     /// The boundaries and paragraph embedding level of each paragraph within the text.
     ///
     /// TODO: Use SmallVec or similar to avoid overhead when there are only one or two paragraphs?
     /// Or just don't include the first paragraph, which always starts at 0?
     pub paragraphs: Vec<ParagraphInfo>,
+}
+
+/// If levels has any RTL (even) level
+///
+/// This information is usually used to skip re-ordering of text when no RTL level is present
+#[inline]
+pub fn has_rtl(levels: &[Level]) -> bool {
+    levels.iter().any(|&lvl| lvl.is_rtl())
+}
+
+impl BidiInfo {
+    /// If processed text has any RTL computed bidi levels
+    ///
+    /// This information is usually used to skip re-ordering of text when no RTL level is present
+    #[inline]
+    pub fn has_rtl(&self) -> bool {
+        self::has_rtl(&self.levels)
+    }
 }
 
 /// Info about a single paragraph
@@ -98,21 +121,26 @@ pub struct ParagraphInfo {
     /// TODO: Shrink this to only include the starting index?
     pub range: Range<usize>,
 
-    /// The paragraph embedding level. http://www.unicode.org/reports/tr9/#BD4
-    pub level: u8,
+    /// The paragraph embedding level.
+    ///
+    /// http://www.unicode.org/reports/tr9/#BD4
+    pub level: Level,
 }
 
-/// Determine the bidirectional embedding levels for a single paragraph.
+/// Split the text into paragraphs and determine the bidirectional embedding levels for each
+/// paragraph.
 ///
 /// TODO: In early steps, check for special cases that allow later steps to be skipped. like text
 /// that is entirely LTR.  See the `nsBidi` class from Gecko for comparison.
-pub fn process_text(text: &str, level: Option<u8>) -> BidiInfo {
+///
+/// TODO: Support auto-RTL base direction
+pub fn process_text(text: &str, level: Option<Level>) -> BidiInfo {
     let InitialProperties {
         initial_classes,
         paragraphs,
     } = initial_scan(text, level);
 
-    let mut levels = Vec::with_capacity(text.len());
+    let mut levels = Vec::<Level>::with_capacity(text.len());
     let mut classes = initial_classes.clone();
 
     for para in &paragraphs {
@@ -142,41 +170,20 @@ pub fn process_text(text: &str, level: Option<u8>) -> BidiInfo {
     }
 }
 
-#[inline]
-/// Even embedding levels are left-to-right.
-///
-/// http://www.unicode.org/reports/tr9/#BD2
-pub fn is_ltr(level: u8) -> bool {
-    level % 2 == 0
-}
-
-#[inline]
-/// Odd levels are right-to-left.
-///
-/// http://www.unicode.org/reports/tr9/#BD2
-pub fn is_rtl(level: u8) -> bool {
-    level % 2 == 1
-}
-
-/// Generate a character type based on a level (as specified in steps X10 and N2).
-fn class_for_level(level: u8) -> BidiClass {
-    if is_rtl(level) { R } else { L }
-}
-
 /// Re-order a line based on resolved levels.
 ///
 /// `levels` are the embedding levels returned by `process_text`.
 /// `line` is a range of bytes indices within `text`.
 ///
 /// Returns the line in display order.
-pub fn reorder_line<'a>(text: &'a str, line: Range<usize>, levels: &[u8]) -> Cow<'a, str> {
+pub fn reorder_line<'a>(text: &'a str, line: Range<usize>, levels: &[Level]) -> Cow<'a, str> {
     let runs = visual_runs(line.clone(), &levels);
-    if runs.len() == 1 && !is_rtl(levels[runs[0].start]) {
+    if runs.len() == 1 && !levels[runs[0].start].is_rtl() {
         return text.into();
     }
     let mut result = String::with_capacity(line.len());
     for run in runs {
-        if is_rtl(levels[run.start]) {
+        if levels[run.start].is_rtl() {
             result.extend(text[run].chars().rev());
         } else {
             result.push_str(&text[run]);
@@ -185,17 +192,12 @@ pub fn reorder_line<'a>(text: &'a str, line: Range<usize>, levels: &[u8]) -> Cow
     result.into()
 }
 
-/// A maximal substring of characters with the same embedding level.
-///
-/// Represented as a range of byte indices.
-pub type LevelRun = Range<usize>;
-
 /// Find the level runs within a line and return them in visual order.
 ///
 /// `line` is a range of bytes indices within `levels`.
 ///
 /// http://www.unicode.org/reports/tr9/#Reordering_Resolved_Levels
-pub fn visual_runs(line: Range<usize>, levels: &[u8]) -> Vec<LevelRun> {
+pub fn visual_runs(line: Range<usize>, levels: &[Level]) -> Vec<LevelRun> {
     assert!(line.start <= levels.len());
     assert!(line.end <= levels.len());
 
@@ -230,7 +232,7 @@ pub fn visual_runs(line: Range<usize>, levels: &[u8]) -> Vec<LevelRun> {
     // http://www.unicode.org/reports/tr9/#L2
 
     // Stop at the lowest *odd* level.
-    min_level |= 1;
+    min_level = min_level.new_lowest_ge_rtl().expect("Level error");
 
     while max_level >= min_level {
         // Look for the start of a sequence of consecutive runs of max_level or higher.
@@ -255,7 +257,9 @@ pub fn visual_runs(line: Range<usize>, levels: &[u8]) -> Vec<LevelRun> {
 
             seq_start = seq_end;
         }
-        max_level -= 1;
+        max_level
+            .lower(1)
+            .expect("Lowering embedding level below zero");
     }
 
     runs
@@ -279,7 +283,7 @@ pub struct InitialProperties {
 /// Also sets the class for each First Strong Isolate initiator (FSI) to LRI or RLI if a strong
 /// character is found before the matching PDI.  If no strong character is found, the class will
 /// remain FSI, and it's up to later stages to treat these as LRI when needed.
-pub fn initial_scan(text: &str, default_para_level: Option<u8>) -> InitialProperties {
+pub fn initial_scan(text: &str, default_para_level: Option<Level>) -> InitialProperties {
     let mut classes = Vec::with_capacity(text.len());
 
     // The stack contains the starting byte index for each nested isolate we're inside.
@@ -288,8 +292,6 @@ pub fn initial_scan(text: &str, default_para_level: Option<u8>) -> InitialProper
 
     let mut para_start = 0;
     let mut para_level = default_para_level;
-
-    const FSI_CHAR: char = '\u{2069}';
 
     for (i, c) in text.char_indices() {
         let class = bidi_class(c);
@@ -303,11 +305,14 @@ pub fn initial_scan(text: &str, default_para_level: Option<u8>) -> InitialProper
                     ParagraphInfo {
                         range: para_start..para_end,
                         // P3. If no character is found in p2, set the paragraph level to zero.
-                        level: para_level.unwrap_or(0),
+                        level: para_level.unwrap_or(Level::ltr()),
                     },
                 );
                 // Reset state for the start of the next paragraph.
                 para_start = para_end;
+                // TODO: Support defaulting to direction of previous paragraph
+                //
+                // http://www.unicode.org/reports/tr9/#HL1
                 para_level = default_para_level;
                 isolate_stack.clear();
             }
@@ -317,7 +322,7 @@ pub fn initial_scan(text: &str, default_para_level: Option<u8>) -> InitialProper
                         if classes[start] == FSI {
                             // X5c. If the first strong character between FSI and its matching PDI
                             // is R or AL, treat it as RLI. Otherwise, treat it as LRI.
-                            for j in 0..FSI_CHAR.len_utf8() {
+                            for j in 0..chars::FSI.len_utf8() {
                                 classes[start + j] = if class == L { LRI } else { RLI };
                             }
                         }
@@ -326,7 +331,13 @@ pub fn initial_scan(text: &str, default_para_level: Option<u8>) -> InitialProper
                         if para_level.is_none() {
                             // P2. Find the first character of type L, AL, or R, while skipping any
                             // characters between an isolate initiator and its matching PDI.
-                            para_level = Some(if class == L { 0 } else { 1 });
+                            para_level = Some(
+                                if class != L {
+                                    Level::rtl()
+                                } else {
+                                    Level::ltr()
+                                },
+                            );
                         }
                     }
                 }
@@ -344,7 +355,7 @@ pub fn initial_scan(text: &str, default_para_level: Option<u8>) -> InitialProper
         paragraphs.push(
             ParagraphInfo {
                 range: para_start..text.len(),
-                level: para_level.unwrap_or(0),
+                level: para_level.unwrap_or(Level::ltr()),
             },
         );
     }
@@ -360,7 +371,7 @@ pub fn initial_scan(text: &str, default_para_level: Option<u8>) -> InitialProper
 ///
 /// The levels assigned to these characters are not specified by the algorithm.  This function
 /// assigns each one the level of the previous character, to avoid breaking level runs.
-fn assign_levels_to_removed_chars(para_level: u8, classes: &[BidiClass], levels: &mut [u8]) {
+fn assign_levels_to_removed_chars(para_level: Level, classes: &[BidiClass], levels: &mut [Level]) {
     for i in 0..levels.len() {
         if prepare::removed_by_x9(classes[i]) {
             levels[i] = if i > 0 { levels[i - 1] } else { para_level };
@@ -369,7 +380,7 @@ fn assign_levels_to_removed_chars(para_level: u8, classes: &[BidiClass], levels:
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
     use super::*;
 
     #[test]
@@ -381,11 +392,12 @@ mod tests {
                 paragraphs: vec![
                     ParagraphInfo {
                         range: 0..2,
-                        level: 0,
+                        level: Level::ltr(),
                     },
                 ],
             }
         );
+
         assert_eq!(
             initial_scan("غ א", None),
             InitialProperties {
@@ -393,33 +405,30 @@ mod tests {
                 paragraphs: vec![
                     ParagraphInfo {
                         range: 0..5,
-                        level: 1,
+                        level: Level::rtl(),
                     },
                 ],
             }
         );
-        {
-            let para1 = ParagraphInfo {
-                range: 0..4,
-                level: 0,
-            };
-            let para2 = ParagraphInfo {
-                range: 4..5,
-                level: 0,
-            };
-            assert_eq!(
-                initial_scan("a\u{2029}b", None),
-                InitialProperties {
-                    initial_classes: vec![L, B, B, B, L],
-                    paragraphs: vec![para1, para2],
-                }
-            );
-        }
 
-        let fsi = '\u{2068}';
-        let pdi = '\u{2069}';
+        assert_eq!(
+            initial_scan("a\u{2029}b", None),
+            InitialProperties {
+                initial_classes: vec![L, B, B, B, L],
+                paragraphs: vec![
+                    ParagraphInfo {
+                        range: 0..4,
+                        level: Level::ltr(),
+                    },
+                    ParagraphInfo {
+                        range: 4..5,
+                        level: Level::ltr(),
+                    },
+                ],
+            }
+        );
 
-        let s = format!("{}א{}a", fsi, pdi);
+        let s = format!("{}א{}a", chars::FSI, chars::PDI);
         assert_eq!(
             initial_scan(&s, None),
             InitialProperties {
@@ -427,7 +436,7 @@ mod tests {
                 paragraphs: vec![
                     ParagraphInfo {
                         range: 0..9,
-                        level: 0,
+                        level: Level::ltr(),
                     },
                 ],
             }
@@ -437,53 +446,53 @@ mod tests {
     #[test]
     fn test_process_text() {
         assert_eq!(
-            process_text("abc123", Some(0)),
+            process_text("abc123", Some(Level::ltr())),
             BidiInfo {
-                levels: vec![0, 0, 0, 0, 0, 0],
+                levels: Level::vec(&[0, 0, 0, 0, 0, 0]),
                 classes: vec![L, L, L, EN, EN, EN],
                 paragraphs: vec![
                     ParagraphInfo {
                         range: 0..6,
-                        level: 0,
+                        level: Level::ltr(),
                     },
                 ],
             }
         );
         assert_eq!(
-            process_text("abc אבג", Some(0)),
+            process_text("abc אבג", Some(Level::ltr())),
             BidiInfo {
-                levels: vec![0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
+                levels: Level::vec(&[0, 0, 0, 0, 1, 1, 1, 1, 1, 1]),
                 classes: vec![L, L, L, WS, R, R, R, R, R, R],
                 paragraphs: vec![
                     ParagraphInfo {
                         range: 0..10,
-                        level: 0,
+                        level: Level::ltr(),
                     },
                 ],
             }
         );
         assert_eq!(
-            process_text("abc אבג", Some(1)),
+            process_text("abc אבג", Some(Level::rtl())),
             BidiInfo {
-                levels: vec![2, 2, 2, 1, 1, 1, 1, 1, 1, 1],
+                levels: Level::vec(&[2, 2, 2, 1, 1, 1, 1, 1, 1, 1]),
                 classes: vec![L, L, L, WS, R, R, R, R, R, R],
                 paragraphs: vec![
                     ParagraphInfo {
                         range: 0..10,
-                        level: 1,
+                        level: Level::rtl(),
                     },
                 ],
             }
         );
         assert_eq!(
-            process_text("אבג abc", Some(0)),
+            process_text("אבג abc", Some(Level::ltr())),
             BidiInfo {
-                levels: vec![1, 1, 1, 1, 1, 1, 0, 0, 0, 0],
+                levels: Level::vec(&[1, 1, 1, 1, 1, 1, 0, 0, 0, 0]),
                 classes: vec![R, R, R, R, R, R, WS, L, L, L],
                 paragraphs: vec![
                     ParagraphInfo {
                         range: 0..10,
-                        level: 0,
+                        level: Level::ltr(),
                     },
                 ],
             }
@@ -491,25 +500,25 @@ mod tests {
         assert_eq!(
             process_text("אבג abc", None),
             BidiInfo {
-                levels: vec![1, 1, 1, 1, 1, 1, 1, 2, 2, 2],
+                levels: Level::vec(&[1, 1, 1, 1, 1, 1, 1, 2, 2, 2]),
                 classes: vec![R, R, R, R, R, R, WS, L, L, L],
                 paragraphs: vec![
                     ParagraphInfo {
                         range: 0..10,
-                        level: 1,
+                        level: Level::rtl(),
                     },
                 ],
             }
         );
         assert_eq!(
-            process_text("غ2ظ א2ג", Some(0)),
+            process_text("غ2ظ א2ג", Some(Level::ltr())),
             BidiInfo {
-                levels: vec![1, 1, 2, 1, 1, 1, 1, 1, 2, 1, 1],
+                levels: Level::vec(&[1, 1, 2, 1, 1, 1, 1, 1, 2, 1, 1]),
                 classes: vec![AL, AL, EN, AL, AL, WS, R, R, EN, R, R],
                 paragraphs: vec![
                     ParagraphInfo {
                         range: 0..11,
-                        level: 0,
+                        level: Level::ltr(),
                     },
                 ],
             }
@@ -518,15 +527,15 @@ mod tests {
             process_text("a א.\nג", None),
             BidiInfo {
                 classes: vec![L, WS, R, R, CS, B, R, R],
-                levels: vec![0, 0, 1, 1, 0, 0, 1, 1],
+                levels: Level::vec(&[0, 0, 1, 1, 0, 0, 1, 1]),
                 paragraphs: vec![
                     ParagraphInfo {
                         range: 0..6,
-                        level: 0,
+                        level: Level::ltr(),
                     },
                     ParagraphInfo {
                         range: 6..8,
-                        level: 1,
+                        level: Level::rtl(),
                     },
                 ],
             }
@@ -534,8 +543,31 @@ mod tests {
     }
 
     #[test]
+    fn test_bidi_info_has_rtl() {
+        // ASCII only
+        assert_eq!(process_text("123", None).has_rtl(), false);
+        assert_eq!(process_text("123", Some(Level::ltr())).has_rtl(), false);
+        assert_eq!(process_text("123", Some(Level::rtl())).has_rtl(), false);
+        assert_eq!(process_text("abc", None).has_rtl(), false);
+        assert_eq!(process_text("abc", Some(Level::ltr())).has_rtl(), false);
+        assert_eq!(process_text("abc", Some(Level::rtl())).has_rtl(), false);
+        assert_eq!(process_text("abc 123", None).has_rtl(), false);
+        assert_eq!(process_text("abc\n123", None).has_rtl(), false);
+
+        // With Hebrew
+        assert_eq!(process_text("אבּג", None).has_rtl(), true);
+        assert_eq!(process_text("אבּג", Some(Level::ltr())).has_rtl(), true);
+        assert_eq!(process_text("אבּג", Some(Level::rtl())).has_rtl(), true);
+        assert_eq!(process_text("abc אבּג", None).has_rtl(), true);
+        assert_eq!(process_text("abc\nאבּג", None).has_rtl(), true);
+        assert_eq!(process_text("אבּג abc", None).has_rtl(), true);
+        assert_eq!(process_text("אבּג\nabc", None).has_rtl(), true);
+        assert_eq!(process_text("אבּג 123", None).has_rtl(), true);
+        assert_eq!(process_text("אבּג\n123", None).has_rtl(), true);
+    }
+
+    #[test]
     fn test_reorder_line() {
-        use std::borrow::Cow;
         fn reorder(s: &str) -> Cow<str> {
             let info = process_text(s, None);
             let para = &info.paragraphs[0];
@@ -570,19 +602,4 @@ mod tests {
             "Hello, \u{2068}\u{202E}\u{202C}dlrow\u{2069}!"
         );
     }
-
-    #[test]
-    fn test_is_ltr() {
-        assert_eq!(is_ltr(10), true);
-        assert_eq!(is_ltr(11), false);
-        assert_eq!(is_ltr(20), true);
-    }
-
-    #[test]
-    fn test_is_rtl() {
-        assert_eq!(is_rtl(13), true);
-        assert_eq!(is_rtl(11), true);
-        assert_eq!(is_rtl(20), false);
-    }
-
 }


### PR DESCRIPTION
The `Level` struct always represents a valid bidi embedding level, therefore can fail on `new*()` and mutation (`raise()`/`lower()`) methods.